### PR TITLE
fix: handle formatted SSE event, add remarkGfm, fix hydration error

### DIFF
--- a/src/components/ChatForm.tsx
+++ b/src/components/ChatForm.tsx
@@ -7,6 +7,7 @@ import { SendHorizontal, FileText, Download, Brain, ClipboardList } from 'lucide
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import ReactMarkdown from 'react-markdown';
 import rehypeHighlight from 'rehype-highlight';
+import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
 import 'katex/dist/katex.min.css';
@@ -392,7 +393,17 @@ export default function ChatForm({ apiBaseUrl: apiBaseUrlProp }: { apiBaseUrl?: 
               console.log('[Streaming] Connected to server');
             } else if (event.type === 'chunk' && event.content) {
               fullResponse += event.content;
-              // Update the assistant message with accumulated content, clear thinking state
+              setMessages((prev) => {
+                const newMessages = [...prev];
+                newMessages[assistantMessageIndex] = {
+                  content: fullResponse,
+                  role: 'assistant',
+                  isThinking: false,
+                };
+                return newMessages;
+              });
+            } else if (event.type === 'formatted' && event.content) {
+              fullResponse = event.content;
               setMessages((prev) => {
                 const newMessages = [...prev];
                 newMessages[assistantMessageIndex] = {
@@ -789,7 +800,7 @@ export default function ChatForm({ apiBaseUrl: apiBaseUrlProp }: { apiBaseUrl?: 
                       </div>
                     ) : (
                       <div className={` ${msg.role === 'user' ? 'whitespace-pre-wrap w-full break-words' : 'prose prose-sm dark:prose-invert max-w-none'}`}>
-                          <ReactMarkdown remarkPlugins={[remarkMath]} rehypePlugins={[rehypeKatex, rehypeHighlight]}>
+                          <ReactMarkdown remarkPlugins={[remarkGfm, remarkMath]} rehypePlugins={[rehypeKatex, rehypeHighlight]}>
                               {msg.content}
                           </ReactMarkdown>
                       </div>

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -395,6 +395,8 @@ export class WidgetAPIClient {
                     yield { type: 'connected' };
                   } else if (data.chunk) {
                     yield { type: 'chunk', content: data.chunk };
+                  } else if (data.event === 'formatted') {
+                    yield { type: 'formatted', content: data.text };
                   } else if (data.event === 'done') {
                     yield { type: 'done', conversationId: data.conversation_id };
                   } else if (data.event === 'error') {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,5 +7,5 @@ const apiBaseUrl = import.meta.env.PUBLIC_API_BASE_URL || 'https://tutoria-api-d
 ---
 
 <Layout>
-  <ChatForm client:load apiBaseUrl={apiBaseUrl} />
+  <ChatForm client:only="react" apiBaseUrl={apiBaseUrl} />
 </Layout>


### PR DESCRIPTION
- Handle 'formatted' SSE event in api-client and ChatForm so the post-processed response from the formatting model replaces the raw streaming chunks instead of being silently dropped
- Add remarkGfm plugin to ReactMarkdown so single-newline AI responses render with proper line breaks instead of collapsing into one paragraph
- Change client:load to client:only="react" to fix React #418 hydration mismatch caused by URL params differing between SSR and client render